### PR TITLE
docs: Fix a few typos

### DIFF
--- a/github3/helpers.py
+++ b/github3/helpers.py
@@ -4,7 +4,7 @@
 github3.helpers
 ~~~~~~~~~~~~~~~
 
-This module contians the helpers.
+This module contains the helpers.
 """
 
 from datetime import datetime

--- a/github3/models.py
+++ b/github3/models.py
@@ -157,7 +157,7 @@ class App(BaseResource):
 
     @property
     def processes(self):
-        """The proccesses for this app."""
+        """The processes for this app."""
         return self._h._get_resources(
             resource=('apps', self.name, 'ps'),
             obj=Process, app=self, map=ProcessListResource


### PR DESCRIPTION
There are small typos in:
- github3/helpers.py
- github3/models.py

Fixes:
- Should read `processes` rather than `proccesses`.
- Should read `contains` rather than `contians`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md